### PR TITLE
Move social icons to page body

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,32 +22,30 @@
     <div class="container">
       <section id="main_content">
         {{ content }}
+        <div><p>2017 © Roberto Ansuini
+          {% if site.twitter_username %}
+           <a style="text-decoration: none" href="https://twitter.com/{{ site.twitter_username }}">
+              <i class="fa fa-twitter"></i>
+           </a> 
+          {% endif %}
+          {% if site.github_username %}
+          <a style="text-decoration: none" href="https://github.com/{{ site.github_username }}">
+            <i class="fa fa-github"></i>
+          </a> 
+          {% endif %}
+          {% if site.linkedin_username %}
+           <a style="text-decoration: none" href="https://linkedin.com/in/{{ site.linkedin_username }}">
+              <i class="fa fa-linkedin"></i>
+            </a>
+          {% endif %}
+          {% if site.medium_publication %}
+           <a style="text-decoration: none" href="https://medium.com/{{ site.medium_publication }}">
+              <i class="fa fa-medium"></i>
+            </a>
+          {% endif %}
+          </p>
+       </div>
       </section>
     </div>
   </body>
- <footer>
-    <div style="position:fixed;left:10px;bottom:10px;height:30px;width:100%;"><p>2017 © Roberto Ansuini
-      {% if site.twitter_username %}
-       <a style="text-decoration: none" href="https://twitter.com/{{ site.twitter_username }}">
-          <i class="fa fa-twitter"></i>
-       </a> 
-      {% endif %}
-      {% if site.github_username %}
-      <a style="text-decoration: none" href="https://github.com/{{ site.github_username }}">
-        <i class="fa fa-github"></i>
-      </a> 
-      {% endif %}
-      {% if site.linkedin_username %}
-       <a style="text-decoration: none" href="https://linkedin.com/in/{{ site.linkedin_username }}">
-          <i class="fa fa-linkedin"></i>
-        </a>
-      {% endif %}
-      {% if site.medium_publication %}
-       <a style="text-decoration: none" href="https://medium.com/{{ site.medium_publication }}">
-          <i class="fa fa-medium"></i>
-        </a>
-      {% endif %}
-      </p>
-   </div>
-  </footer>
 </html>


### PR DESCRIPTION
This change relocates the social media icons from the footer to the main content area of the page. The icons are now displayed directly below the page content, integrating them more closely with the rest of the site.

The fixed positioning styling has been removed from the icons' container div to allow them to flow naturally with the page content.