### PR TITLE
fix: Update copyright year to 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
         </div>
 
         <footer>
-            <p>© 2025 Roberto Ansuini · Always evolving, always learning</p>
+            <p>© 2026 Roberto Ansuini · Always evolving, always learning</p>
         </footer>
     </div>
 </body>


### PR DESCRIPTION
## 📅 Copyright Year Update

Update footer copyright from 2025 → 2026.

### Changes
- Footer: `© 2025` → `© 2026`

Simple one-liner fix! 🗓️