### PR TITLE
feat: Add Plausible custom event tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,8 +264,34 @@
         </div>
 
         <footer>
-            <p>© 2025 Roberto Ansuini · Always evolving, always learning</p>
+            <p>© 2026 Roberto Ansuini · Always evolving, always learning</p>
         </footer>
     </div>
+
+    <script>
+        // Plausible custom event tracking
+        window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+
+        // Track social link clicks
+        document.querySelectorAll('.social-links a').forEach(link => {
+            link.addEventListener('click', function(e) {
+                const platform = this.title; // "Twitter/X", "LinkedIn", "GitHub"
+                plausible('Social Click', {props: {platform: platform}});
+            });
+        });
+
+        // Track project link clicks
+        document.querySelectorAll('.project-link').forEach(link => {
+            link.addEventListener('click', function(e) {
+                const project = this.closest('.project-card').querySelector('h3').textContent;
+                plausible('Project Click', {props: {project: project}});
+            });
+        });
+
+        // Track newsletter CTA
+        document.querySelector('.cta-box .btn').addEventListener('click', function(e) {
+            plausible('Newsletter CTA', {props: {location: 'main-cta-box'}});
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## 📊 Plausible Event Tracking

### What This Adds

**Custom events to track visitor engagement:**

1. **Social Click** → Track which social platform visitors click
   - Props: `{platform: "Twitter/X" | "LinkedIn" | "GitHub"}`
   - Locations: Header social links

2. **Project Click** → Track which project visitors explore
   - Props: `{project: "leadingin.tech" | "the.leadingintech.email"}`
   - Locations: Project cards

3. **Newsletter CTA** → Track newsletter signup intent
   - Props: `{location: "main-cta-box"}`
   - Location: Blue CTA box

### How It Works

Adds event listeners to all tracked elements. When clicked, sends custom events to Plausible with contextual properties.

### Next Steps After Merge

**In your Plausible dashboard (https://plausible.io/robansuini.com):**

1. Go to **Settings** → **Goals**
2. Click **+ Add goal**
3. Add these custom events:
   - `Social Click`
   - `Project Click`
   - `Newsletter CTA`

**View the data:**
- Main dashboard will show these events under "Goal Conversions"
- Click any goal to see breakdown by props (which platform, which project, etc.)

### Also Included
- ✅ Fixed copyright year: 2025 → 2026

---

**After this is live, you'll be able to answer:**
- Which social platform do visitors prefer?
- Are people more interested in the toolkit or newsletter?
- Is the CTA effective?
- Conversion rates for each action