### PR TITLE
Align About + What I'm Building copy with leadingin.tech profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,9 +234,9 @@
             
             <div class="project-card">
                 <h3>leadingin.tech</h3>
-                <p class="project-meta">Toolkit for Engineering Leaders</p>
+                <p class="project-meta">Practical toolkit for engineering leaders</p>
                 <p>
-                    A collection of practical tools, frameworks, and resources to help engineering managers grow their teams and themselves. Built from real experience, not theory.
+                    A collection of tools, frameworks, and resources to help engineering managers grow their teams and themselves. Built from real experience, not theory. No fluff, just practical insights that actually help.
                 </p>
                 <a href="https://leadingin.tech" class="project-link" target="_blank">
                     Visit the toolkit <i class="fa-solid fa-arrow-right"></i>
@@ -245,12 +245,23 @@
 
             <div class="project-card">
                 <h3>the.leadingintech.email</h3>
-                <p class="project-meta">Newsletter on Leadership in Tech</p>
+                <p class="project-meta">Weekly newsletter on leadership in tech</p>
                 <p>
-                    Weekly insights on engineering leadership, team dynamics, and the challenges nobody warns you about. Personal observations, not prescriptive how-tos.
+                    Personal observations on engineering leadership, team dynamics, and the challenges nobody warns you about. Not prescriptive how-tos—honest reflections on what actually works (and what doesn't).
                 </p>
                 <a href="https://the.leadingintech.email" class="project-link" target="_blank">
                     Read the newsletter <i class="fa-solid fa-arrow-right"></i>
+                </a>
+            </div>
+
+            <div class="project-card">
+                <h3>agent-skills</h3>
+                <p class="project-meta">Open-source skills for AI coding agents</p>
+                <p>
+                    AgentSkills.io-compatible skills for Claude Code, OpenClaw, Windsurf, and other AI coding tools. Automation and workflows that actually ship.
+                </p>
+                <a href="https://github.com/robansuini/agent-skills" class="project-link" target="_blank">
+                    Explore the repository <i class="fa-solid fa-arrow-right"></i>
                 </a>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Roberto Ansuini - Engineering Leadership & Tools</title>
-    <meta name="description" content="Engineering manager since 2011. Building tools to help engineering leaders grow their teams. Venezuelan living in Madrid.">
+    <meta name="description" content="Engineering manager since 2011. Helping people and technology work better together through practical leadership tools and insights.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <script async defer data-domain="robansuini.com" src="https://robansuini-work.nsuini.workers.dev/js/script.js"></script>
     <style>
@@ -222,10 +222,10 @@
         <section id="about">
             <h2>About</h2>
             <p class="about-intro">
-                I'm a Venezuelan engineer living in Madrid, helping engineering managers lead better teams. After 15+ years managing teams, I've learned that most leadership challenges aren't technical—they're about seeing your own blindspots and building the right guardrails.
+                Hi, I'm Roberto—an Engineering Manager passionate about helping people and technology work better together. Great engineering isn't just about code; it's about the people behind it, the systems they build, and the impact they create.
             </p>
             <p>
-                That's why I'm building <strong>leadingin.tech</strong>—a practical toolkit for engineering leaders who want to grow without burning out. No fluff, no theory. Just tools and insights that actually help.
+                My approach is pragmatic and grounded in real-world problem solving. That's why I'm building <strong>leadingin.tech</strong>: practical tools, frameworks, and insights for engineering leaders who want to grow teams, stay focused on outcomes, and avoid burnout.
             </p>
         </section>
 


### PR DESCRIPTION
## Summary
- Align robansuini.com copy with the tone and messaging used in leadingin.tech and GitHub profile
- Remove the nationality mention from About copy as requested
- Keep wording practical, concise, and leadership-focused

## Changes
### About section
- Update meta description in index.html
- Rewrite About intro paragraph
- Rewrite second About paragraph for practical leadership positioning

### What I’m Building section
- Refresh copy for leadingin.tech
- Refresh copy for the.leadingintech.email
- Add agent-skills project card + GitHub link

## Notes
- This PR only updates website copy/content (no layout or behavior changes).
