### PR TITLE
Add favicon to robansuini.com

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,10 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="RA">
-  <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#2563eb"/>
-      <stop offset="100%" stop-color="#1e40af"/>
-    </linearGradient>
-  </defs>
-  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#g)"/>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="#111111"/>
   <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,sans-serif" font-size="24" font-weight="700" fill="#ffffff">RA</text>
 </svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="RA">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#1e40af"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#g)"/>
+  <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,sans-serif" font-size="24" font-weight="700" fill="#ffffff">RA</text>
+</svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="RA">
   <rect x="4" y="4" width="56" height="56" rx="12" fill="#111111"/>
-  <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,sans-serif" font-size="24" font-weight="700" fill="#ffffff">RA</text>
+  <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" font-family="'Press Start 2P', monospace" font-size="18" font-weight="700" fill="#ffffff">RA</text>
 </svg>


### PR DESCRIPTION
## Summary
- add a favicon for robansuini.com

## Changes
- add `favicon.svg` (RA monogram)
- add `<link rel="icon" type="image/svg+xml" href="/favicon.svg">` in `index.html`

## Notes
- lightweight SVG favicon, no layout changes.