### PR TITLE
fix: harden external links and add link safety CI check

### DIFF
--- a/.github/workflows/site-checks.yml
+++ b/.github/workflows/site-checks.yml
@@ -1,0 +1,19 @@
+name: Site checks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  external-link-safety:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Validate target="_blank" links are safe
+        run: node scripts/check-external-links.js

--- a/README.md
+++ b/README.md
@@ -29,9 +29,17 @@ python3 -m http.server 8000
 # Visit http://localhost:8000
 ```
 
+**Quality checks:**
+```bash
+node scripts/check-external-links.js
+```
+
+This validates that every `target="_blank"` link includes `rel="noopener noreferrer"` to prevent reverse-tabnabbing.
+
 **Deploy:**
 - Push/merge to `master` → auto-deploys to GitHub Pages
 - Deployment takes ~1-2 minutes
+- GitHub Actions runs `site-checks` on pushes/PRs
 
 ## 📊 Performance
 
@@ -45,4 +53,4 @@ Personal site - all rights reserved.
 
 ---
 
-**Last updated:** February 2026 (v8 - Modern redesign)
+**Last updated:** February 2026 (v9 - Link security hardening + CI checks)

--- a/index.html
+++ b/index.html
@@ -212,9 +212,9 @@
                 <h1>Roberto Ansuini</h1>
                 <p class="tagline">Engineering manager since 2011. Building tools to help engineering leaders grow their teams.</p>
                 <div class="social-links">
-                    <a href="https://x.com/robansuini" title="Twitter/X" target="_blank"><i class="fa-brands fa-x-twitter"></i></a>
-                    <a href="https://linkedin.com/in/robansuini" title="LinkedIn" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
-                    <a href="https://github.com/robansuini" title="GitHub" target="_blank"><i class="fa-brands fa-github"></i></a>
+                    <a href="https://x.com/robansuini" title="Twitter/X" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
+                    <a href="https://linkedin.com/in/robansuini" title="LinkedIn" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-linkedin"></i></a>
+                    <a href="https://github.com/robansuini" title="GitHub" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i></a>
                 </div>
             </div>
         </header>
@@ -238,7 +238,7 @@
                 <p>
                     A collection of tools, frameworks, and resources to help engineering managers grow their teams and themselves. Built from real experience, not theory. No fluff, just practical insights that actually help.
                 </p>
-                <a href="https://leadingin.tech" class="project-link" target="_blank">
+                <a href="https://leadingin.tech" class="project-link" target="_blank" rel="noopener noreferrer">
                     Visit the toolkit <i class="fa-solid fa-arrow-right"></i>
                 </a>
             </div>
@@ -249,7 +249,7 @@
                 <p>
                     Personal observations on engineering leadership, team dynamics, and the challenges nobody warns you about. Not prescriptive how-tos—honest reflections on what actually works (and what doesn't).
                 </p>
-                <a href="https://the.leadingintech.email" class="project-link" target="_blank">
+                <a href="https://the.leadingintech.email" class="project-link" target="_blank" rel="noopener noreferrer">
                     Read the newsletter <i class="fa-solid fa-arrow-right"></i>
                 </a>
             </div>
@@ -260,7 +260,7 @@
                 <p>
                     AgentSkills.io-compatible skills for Claude Code, OpenClaw, Windsurf, and other AI coding tools. Automation and workflows that actually ship.
                 </p>
-                <a href="https://github.com/robansuini/agent-skills" class="project-link" target="_blank">
+                <a href="https://github.com/robansuini/agent-skills" class="project-link" target="_blank" rel="noopener noreferrer">
                     Explore the repository <i class="fa-solid fa-arrow-right"></i>
                 </a>
             </div>

--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const htmlPath = path.join(process.cwd(), 'index.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+
+const anchorTagRegex = /<a\b[^>]*>/gi;
+const targetBlankRegex = /\btarget\s*=\s*(["'])_blank\1/i;
+const relRegex = /\brel\s*=\s*(["'])(.*?)\1/i;
+
+const failures = [];
+let match;
+
+while ((match = anchorTagRegex.exec(html)) !== null) {
+  const tag = match[0];
+
+  if (!targetBlankRegex.test(tag)) {
+    continue;
+  }
+
+  const relMatch = tag.match(relRegex);
+  if (!relMatch) {
+    failures.push({
+      index: match.index,
+      reason: 'missing rel attribute',
+      tag,
+    });
+    continue;
+  }
+
+  const relTokens = new Set(
+    relMatch[2]
+      .split(/\s+/)
+      .map(token => token.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  if (!relTokens.has('noopener') || !relTokens.has('noreferrer')) {
+    failures.push({
+      index: match.index,
+      reason: 'rel must include both noopener and noreferrer',
+      tag,
+    });
+  }
+}
+
+if (failures.length > 0) {
+  console.error('External link safety check failed.');
+  for (const failure of failures) {
+    console.error(`- ${failure.reason} @ index ${failure.index}: ${failure.tag}`);
+  }
+  process.exit(1);
+}
+
+console.log('External link safety check passed.');


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to all external links opened with `target="_blank"`
- add `scripts/check-external-links.js` to enforce safe external-link attributes
- add a GitHub Actions workflow (`site-checks`) to run the link safety check on PRs/pushes
- update README development docs with the new quality check command

## Why
This hardens the site against reverse-tabnabbing and adds a lightweight automated guardrail so future edits cannot accidentally reintroduce unsafe external links.

## Validation
- `node scripts/check-external-links.js`
