### PR TITLE
chore: scan all HTML files in external link safety check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python3 -m http.server 8000
 node scripts/check-external-links.js
 ```
 
-This validates that every `target="_blank"` link includes `rel="noopener noreferrer"` to prevent reverse-tabnabbing.
+This validates that every `target="_blank"` link across all repo HTML files includes `rel="noopener noreferrer"` to prevent reverse-tabnabbing.
 
 **Deploy:**
 - Push/merge to `master` → auto-deploys to GitHub Pages

--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -3,55 +3,97 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const htmlPath = path.join(process.cwd(), 'index.html');
-const html = fs.readFileSync(htmlPath, 'utf8');
+const rootDir = process.cwd();
+const SKIP_DIRS = new Set(['.git', 'node_modules']);
 
 const anchorTagRegex = /<a\b[^>]*>/gi;
 const targetBlankRegex = /\btarget\s*=\s*(["'])_blank\1/i;
 const relRegex = /\brel\s*=\s*(["'])(.*?)\1/i;
 
+function findHtmlFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findHtmlFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function checkHtmlFile(html, filePath) {
+  const failures = [];
+  let match;
+
+  while ((match = anchorTagRegex.exec(html)) !== null) {
+    const tag = match[0];
+
+    if (!targetBlankRegex.test(tag)) {
+      continue;
+    }
+
+    const relMatch = tag.match(relRegex);
+    if (!relMatch) {
+      failures.push({
+        filePath,
+        index: match.index,
+        reason: 'missing rel attribute',
+        tag,
+      });
+      continue;
+    }
+
+    const relTokens = new Set(
+      relMatch[2]
+        .split(/\s+/)
+        .map(token => token.trim().toLowerCase())
+        .filter(Boolean),
+    );
+
+    if (!relTokens.has('noopener') || !relTokens.has('noreferrer')) {
+      failures.push({
+        filePath,
+        index: match.index,
+        reason: 'rel must include both noopener and noreferrer',
+        tag,
+      });
+    }
+  }
+
+  return failures;
+}
+
+const htmlFiles = findHtmlFiles(rootDir).sort();
+if (htmlFiles.length === 0) {
+  console.error('No HTML files found to validate.');
+  process.exit(1);
+}
+
 const failures = [];
-let match;
-
-while ((match = anchorTagRegex.exec(html)) !== null) {
-  const tag = match[0];
-
-  if (!targetBlankRegex.test(tag)) {
-    continue;
-  }
-
-  const relMatch = tag.match(relRegex);
-  if (!relMatch) {
-    failures.push({
-      index: match.index,
-      reason: 'missing rel attribute',
-      tag,
-    });
-    continue;
-  }
-
-  const relTokens = new Set(
-    relMatch[2]
-      .split(/\s+/)
-      .map(token => token.trim().toLowerCase())
-      .filter(Boolean),
-  );
-
-  if (!relTokens.has('noopener') || !relTokens.has('noreferrer')) {
-    failures.push({
-      index: match.index,
-      reason: 'rel must include both noopener and noreferrer',
-      tag,
-    });
-  }
+for (const filePath of htmlFiles) {
+  const html = fs.readFileSync(filePath, 'utf8');
+  anchorTagRegex.lastIndex = 0;
+  failures.push(...checkHtmlFile(html, path.relative(rootDir, filePath)));
 }
 
 if (failures.length > 0) {
   console.error('External link safety check failed.');
   for (const failure of failures) {
-    console.error(`- ${failure.reason} @ index ${failure.index}: ${failure.tag}`);
+    console.error(`- ${failure.reason} in ${failure.filePath} @ index ${failure.index}: ${failure.tag}`);
   }
   process.exit(1);
 }
 
-console.log('External link safety check passed.');
+console.log(`External link safety check passed (${htmlFiles.length} HTML file(s) scanned).`);


### PR DESCRIPTION
## Summary
- update `scripts/check-external-links.js` to recursively scan all `.html` files in the repo instead of only `index.html`
- preserve existing reverse-tabnabbing guard (`target="_blank"` must include `rel="noopener noreferrer"`)
- improve failure output to include file path + index and success output to include scanned file count
- update README quality-check text to match the expanded script scope

## Why
This keeps the safety guardrail effective if/when additional HTML pages are added, without adding dependencies or changing runtime site behavior.

## Validation
- `node scripts/check-external-links.js` ✅
  - `External link safety check passed (1 HTML file(s) scanned).`

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [x] Exactly one completion update posted to topic 713
