### PR TITLE
fix: add sitemap for personal site

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Personal website of Roberto Ansuini - Engineering manager, leadership toolkit cr
 - **GitHub Pages** - Deployed automatically from `master` branch
 - **Font Awesome** - Icons
 - **Plausible Analytics** - Privacy-friendly analytics
+- **robots.txt + sitemap.xml** - Search crawler metadata for the canonical homepage
 
 ## 📝 Content
 
@@ -53,4 +54,4 @@ Personal site - all rights reserved.
 
 ---
 
-**Last updated:** February 2026 (v9 - Link security hardening + CI checks)
+**Last updated:** May 2026 (v10 - Sitemap coverage)

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://robansuini.com/</loc>
+    <lastmod>2026-05-02</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a static `sitemap.xml` matching the existing `robots.txt` sitemap reference
- document crawler metadata coverage in the README and refresh the version note

## Validation
- `node scripts/check-external-links.js` ✅
- `node --test scripts/check-external-links.test.js` ✅
- `python3 tmp-validate-sitemap.py` ✅ (`sitemap.xml` parsed and canonical homepage URL verified)

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [x] Exactly one completion update posted to topic 713

## Risk
Low. Static SEO metadata only; rollback is reverting this PR.
