### PR TITLE
refactor: isolate rel token validation

### DIFF
--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const SKIP_DIRS = new Set(['.git', 'node_modules']);
+const REQUIRED_REL_TOKENS = new Set(['noopener', 'noreferrer']);
 
 const anchorTagRegex = /<a\b[^>]*>/gi;
 
@@ -27,6 +28,27 @@ function getLineColumn(text, index) {
   const lastNewline = upToIndex.lastIndexOf('\n');
   const column = safeIndex - lastNewline;
   return { line, column };
+}
+
+function getRelTokens(rel) {
+  return new Set(
+    rel
+      .split(/\s+/)
+      .map(token => token.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function hasRequiredRelTokens(rel) {
+  const relTokens = getRelTokens(rel);
+
+  for (const requiredToken of REQUIRED_REL_TOKENS) {
+    if (!relTokens.has(requiredToken)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function findHtmlFiles(dir) {
@@ -79,14 +101,7 @@ function checkHtmlFile(html, filePath) {
       continue;
     }
 
-    const relTokens = new Set(
-      rel
-        .split(/\s+/)
-        .map(token => token.trim().toLowerCase())
-        .filter(Boolean),
-    );
-
-    if (!relTokens.has('noopener') || !relTokens.has('noreferrer')) {
+    if (!hasRequiredRelTokens(rel)) {
       failures.push({
         filePath,
         index: match.index,
@@ -158,6 +173,8 @@ module.exports = {
   checkHtmlFile,
   findHtmlFiles,
   getLineColumn,
+  getRelTokens,
+  hasRequiredRelTokens,
   run,
 };
 

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -4,13 +4,33 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { checkHtmlFile, getLineColumn, run } = require('./check-external-links.js');
+const {
+  checkHtmlFile,
+  getLineColumn,
+  getRelTokens,
+  hasRequiredRelTokens,
+  run,
+} = require('./check-external-links.js');
 
 test('getLineColumn returns 1-based line/column', () => {
   const text = 'first\nsecond\nthird';
   assert.deepEqual(getLineColumn(text, 0), { line: 1, column: 1 });
   assert.deepEqual(getLineColumn(text, 8), { line: 2, column: 3 });
   assert.deepEqual(getLineColumn(text, text.length), { line: 3, column: 6 });
+});
+
+test('getRelTokens normalizes whitespace, duplicates, and case', () => {
+  assert.deepEqual([...getRelTokens('  NoOpener  noreferrer noopener  ')], [
+    'noopener',
+    'noreferrer',
+  ]);
+});
+
+test('hasRequiredRelTokens requires noopener and noreferrer', () => {
+  assert.equal(hasRequiredRelTokens('noopener noreferrer'), true);
+  assert.equal(hasRequiredRelTokens('external noreferrer noopener'), true);
+  assert.equal(hasRequiredRelTokens('noopener'), false);
+  assert.equal(hasRequiredRelTokens('noreferrer'), false);
 });
 
 test('checkHtmlFile passes when target=_blank includes noopener noreferrer', () => {


### PR DESCRIPTION
## Summary

Refactors the external link safety checker so required `rel` token validation lives in dedicated helpers instead of inline scan logic.

## Changes

- Added `getRelTokens()` and `hasRequiredRelTokens()` helpers for normalized rel-token handling.
- Reused the helper from `checkHtmlFile()` to keep validation behavior unchanged.
- Added focused Node test coverage for token normalization and required-token checks.

## Testing

- `node scripts/check-external-links.js` ✅
- `node --test scripts/check-external-links.test.js` ✅
- `git diff --check` ✅

## Risk

Low; single-module cleanup with unchanged external-link validation behavior.

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [x] Exactly one completion update posted to topic 713
