### PR TITLE
fix: ignore commented external links

### DIFF
--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -29,6 +29,29 @@ function getLineColumn(text, index) {
   return { line, column };
 }
 
+function findHtmlCommentRanges(html) {
+  const ranges = [];
+  let searchIndex = 0;
+
+  while (searchIndex < html.length) {
+    const start = html.indexOf('<!--', searchIndex);
+    if (start === -1) {
+      break;
+    }
+
+    const closeIndex = html.indexOf('-->', start + 4);
+    const end = closeIndex === -1 ? html.length : closeIndex + 3;
+    ranges.push({ start, end });
+    searchIndex = end;
+  }
+
+  return ranges;
+}
+
+function isIndexInRanges(index, ranges) {
+  return ranges.some(range => index >= range.start && index < range.end);
+}
+
 function findHtmlFiles(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   const files = [];
@@ -54,9 +77,14 @@ function findHtmlFiles(dir) {
 
 function checkHtmlFile(html, filePath) {
   const failures = [];
+  const commentRanges = findHtmlCommentRanges(html);
   let match;
 
   while ((match = anchorTagRegex.exec(html)) !== null) {
+    if (isIndexInRanges(match.index, commentRanges)) {
+      continue;
+    }
+
     const tag = match[0];
 
     const target = getAttributeValue(tag, 'target');

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -53,6 +53,22 @@ test('checkHtmlFile passes for unquoted target=_blank with valid rel tokens', ()
   assert.equal(failures.length, 0);
 });
 
+test('checkHtmlFile ignores unsafe anchors inside HTML comments', () => {
+  const html = '<!-- <a href="https://example.com" target="_blank">commented out</a> -->';
+  const failures = checkHtmlFile(html, 'index.html');
+
+  assert.equal(failures.length, 0);
+});
+
+test('checkHtmlFile still reports unsafe anchors after HTML comments', () => {
+  const html = '<!-- <a href="https://safe-to-ignore.com" target="_blank">ignore</a> -->\n<a href="https://example.com" target="_blank">bad</a>';
+  const failures = checkHtmlFile(html, 'index.html');
+
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].reason, 'missing rel attribute');
+  assert.equal(failures[0].line, 2);
+});
+
 test('run scans nested html files and reports file count on success', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'link-check-pass-'));
 


### PR DESCRIPTION
## Summary
- Ignore `<a>` tags inside HTML comments during external-link safety validation.
- Add regression coverage so commented-out unsafe snippets do not fail the checker while real unsafe anchors still do.

## Validation
- `node --test scripts/check-external-links.test.js` ✅
- `node scripts/check-external-links.js` ✅

## Risk
- Low; rendered anchors are still validated, this only avoids false positives in comments.

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [x] Exactly one completion update posted to topic 713
