### PR TITLE
fix: label social icon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,9 +212,9 @@
                 <h1>Roberto Ansuini</h1>
                 <p class="tagline">Engineering manager since 2011. Building tools to help engineering leaders grow their teams.</p>
                 <div class="social-links">
-                    <a href="https://x.com/robansuini" title="Twitter/X" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
-                    <a href="https://linkedin.com/in/robansuini" title="LinkedIn" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-linkedin"></i></a>
-                    <a href="https://github.com/robansuini" title="GitHub" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i></a>
+                    <a href="https://x.com/robansuini" title="Twitter/X" aria-label="Twitter/X" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
+                    <a href="https://linkedin.com/in/robansuini" title="LinkedIn" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-linkedin"></i></a>
+                    <a href="https://github.com/robansuini" title="GitHub" aria-label="GitHub" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i></a>
                 </div>
             </div>
         </header>

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -6,6 +6,11 @@ const path = require('node:path');
 
 const { checkHtmlFile, getLineColumn, run } = require('./check-external-links.js');
 
+function getAttributeValue(tag, attributeName) {
+  const attributeRegex = new RegExp(`\\b${attributeName}\\s*=\\s*"([^"]*)"`, 'i');
+  return tag.match(attributeRegex)?.[1] ?? null;
+}
+
 test('getLineColumn returns 1-based line/column', () => {
   const text = 'first\nsecond\nthird';
   assert.deepEqual(getLineColumn(text, 0), { line: 1, column: 1 });
@@ -51,6 +56,23 @@ test('checkHtmlFile passes for unquoted target=_blank with valid rel tokens', ()
   const failures = checkHtmlFile(html, 'index.html');
 
   assert.equal(failures.length, 0);
+});
+
+test('site social links have explicit accessible labels', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const socialLinks = html.match(/<div class="social-links">([\s\S]*?)<\/div>/);
+
+  assert.ok(socialLinks, 'expected social links block to exist');
+
+  const socialAnchorTags = [...socialLinks[1].matchAll(/<a\b[^>]*>/g)].map(match => match[0]);
+  assert.deepEqual(
+    socialAnchorTags.map(tag => getAttributeValue(tag, 'aria-label')),
+    ['Twitter/X', 'LinkedIn', 'GitHub'],
+  );
+
+  for (const tag of socialAnchorTags) {
+    assert.equal(getAttributeValue(tag, 'aria-label'), getAttributeValue(tag, 'title'));
+  }
 });
 
 test('run scans nested html files and reports file count on success', () => {


### PR DESCRIPTION
## Summary
- Add explicit aria-label values to the icon-only social links in the site header.
- Preserve the existing title, target, and rel attributes so visual behavior and link safety stay unchanged.
- Add a focused regression assertion so the social links keep explicit accessible labels.

## Validation
- `node scripts/check-external-links.js` - passed
- `node --test scripts/check-external-links.test.js` - passed (10 tests)
- `git diff --check` - passed

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [ ] Exactly one completion update posted to topic 713
