### PR TITLE
fix: tighten external link attribute matching

### DIFF
--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -9,7 +9,7 @@ const anchorTagRegex = /<a\b[^>]*>/gi;
 
 function getAttributeValue(tag, attributeName) {
   const attributeRegex = new RegExp(
-    `\\b${attributeName}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\`]+))`,
+    `(?:^|\\s)${attributeName}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\`]+))`,
     'i',
   );
   const match = tag.match(attributeRegex);

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -30,6 +30,22 @@ test('checkHtmlFile fails when rel attribute is missing', () => {
   assert.equal(failures[0].column, 3);
 });
 
+test('checkHtmlFile ignores prefixed target attributes', () => {
+  const html = '<a href="https://example.com" data-target="_blank">ok</a>';
+  const failures = checkHtmlFile(html, 'index.html');
+
+  assert.equal(failures.length, 0);
+});
+
+test('checkHtmlFile ignores prefixed rel attributes', () => {
+  const html =
+    '<a href="https://example.com" target="_blank" data-rel="noopener noreferrer">bad</a>';
+  const failures = checkHtmlFile(html, 'index.html');
+
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].reason, 'missing rel attribute');
+});
+
 test('checkHtmlFile fails for unquoted target=_blank when rel is missing', () => {
   const html = '<a href="https://example.com" target=_blank>bad</a>';
   const failures = checkHtmlFile(html, 'index.html');


### PR DESCRIPTION
## Summary
- Tighten external-link checker attribute matching so `data-target` and `data-rel` are not treated as real `target`/`rel` attributes.
- Add regression tests for prefixed attribute names.

## Validation
- `node --test scripts/check-external-links.test.js` - passed on 2026-05-31; 11 tests passed.
- `node scripts/check-external-links.js` - passed on 2026-05-31; 1 HTML file scanned.
- `git diff --check origin/master...HEAD` - passed on 2026-05-31.

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [x] Exactly one completion update posted to topic 713
