### PR TITLE
refactor: isolate anchor tag scanning

### DIFF
--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const SKIP_DIRS = new Set(['.git', 'node_modules']);
+const REQUIRED_BLANK_TARGET_REL_TOKENS = ['noopener', 'noreferrer'];
 
 function getAttributeValue(tag, attributeName) {
   const attributeRegex = new RegExp(
@@ -23,6 +24,31 @@ function findAnchorTags(html) {
     tag: match[0],
     index: match.index ?? 0,
   }));
+}
+
+function getBlankTargetRelFailureReason(tag) {
+  const target = getAttributeValue(tag, 'target');
+  if (!target || target.toLowerCase() !== '_blank') {
+    return null;
+  }
+
+  const rel = getAttributeValue(tag, 'rel');
+  if (rel === null) {
+    return 'missing rel attribute';
+  }
+
+  const relTokens = new Set(
+    rel
+      .split(/\s+/)
+      .map(token => token.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  if (REQUIRED_BLANK_TARGET_REL_TOKENS.every(token => relTokens.has(token))) {
+    return null;
+  }
+
+  return 'rel must include both noopener and noreferrer';
 }
 
 function getLineColumn(text, index) {
@@ -61,43 +87,21 @@ function checkHtmlFile(html, filePath) {
   const failures = [];
 
   for (const { tag, index } of findAnchorTags(html)) {
-    const target = getAttributeValue(tag, 'target');
-    if (!target || target.toLowerCase() !== '_blank') {
+    const reason = getBlankTargetRelFailureReason(tag);
+
+    if (reason === null) {
       continue;
     }
 
     const location = getLineColumn(html, index);
-
-    const rel = getAttributeValue(tag, 'rel');
-    if (rel === null) {
-      failures.push({
-        filePath,
-        index,
-        line: location.line,
-        column: location.column,
-        reason: 'missing rel attribute',
-        tag,
-      });
-      continue;
-    }
-
-    const relTokens = new Set(
-      rel
-        .split(/\s+/)
-        .map(token => token.trim().toLowerCase())
-        .filter(Boolean),
-    );
-
-    if (!relTokens.has('noopener') || !relTokens.has('noreferrer')) {
-      failures.push({
-        filePath,
-        index,
-        line: location.line,
-        column: location.column,
-        reason: 'rel must include both noopener and noreferrer',
-        tag,
-      });
-    }
+    failures.push({
+      filePath,
+      index,
+      line: location.line,
+      column: location.column,
+      reason,
+      tag,
+    });
   }
 
   return failures;
@@ -159,6 +163,7 @@ module.exports = {
   checkHtmlFile,
   findAnchorTags,
   findHtmlFiles,
+  getBlankTargetRelFailureReason,
   getLineColumn,
   run,
 };

--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -20,10 +20,51 @@ function getAttributeValue(tag, attributeName) {
 }
 
 function findAnchorTags(html) {
-  return Array.from(html.matchAll(/<a\b[^>]*>/gi), match => ({
-    tag: match[0],
-    index: match.index ?? 0,
-  }));
+  const tags = [];
+  const anchorStartRegex = /<a\b/gi;
+  let match;
+
+  while ((match = anchorStartRegex.exec(html)) !== null) {
+    const index = match.index ?? 0;
+    const endIndex = findTagEnd(html, anchorStartRegex.lastIndex);
+    if (endIndex === -1) {
+      continue;
+    }
+
+    tags.push({
+      tag: html.slice(index, endIndex + 1),
+      index,
+    });
+    anchorStartRegex.lastIndex = endIndex + 1;
+  }
+
+  return tags;
+}
+
+function findTagEnd(html, startIndex) {
+  let quote = null;
+
+  for (let index = startIndex; index < html.length; index += 1) {
+    const char = html[index];
+
+    if (quote !== null) {
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === '>') {
+      return index;
+    }
+  }
+
+  return -1;
 }
 
 function getBlankTargetRelFailureReason(tag) {

--- a/scripts/check-external-links.js
+++ b/scripts/check-external-links.js
@@ -5,8 +5,6 @@ const path = require('node:path');
 
 const SKIP_DIRS = new Set(['.git', 'node_modules']);
 
-const anchorTagRegex = /<a\b[^>]*>/gi;
-
 function getAttributeValue(tag, attributeName) {
   const attributeRegex = new RegExp(
     `\\b${attributeName}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\`]+))`,
@@ -18,6 +16,13 @@ function getAttributeValue(tag, attributeName) {
   }
 
   return match[1] ?? match[2] ?? match[3] ?? '';
+}
+
+function findAnchorTags(html) {
+  return Array.from(html.matchAll(/<a\b[^>]*>/gi), match => ({
+    tag: match[0],
+    index: match.index ?? 0,
+  }));
 }
 
 function getLineColumn(text, index) {
@@ -54,23 +59,20 @@ function findHtmlFiles(dir) {
 
 function checkHtmlFile(html, filePath) {
   const failures = [];
-  let match;
 
-  while ((match = anchorTagRegex.exec(html)) !== null) {
-    const tag = match[0];
-
+  for (const { tag, index } of findAnchorTags(html)) {
     const target = getAttributeValue(tag, 'target');
     if (!target || target.toLowerCase() !== '_blank') {
       continue;
     }
 
-    const location = getLineColumn(html, match.index);
+    const location = getLineColumn(html, index);
 
     const rel = getAttributeValue(tag, 'rel');
     if (rel === null) {
       failures.push({
         filePath,
-        index: match.index,
+        index,
         line: location.line,
         column: location.column,
         reason: 'missing rel attribute',
@@ -89,7 +91,7 @@ function checkHtmlFile(html, filePath) {
     if (!relTokens.has('noopener') || !relTokens.has('noreferrer')) {
       failures.push({
         filePath,
-        index: match.index,
+        index,
         line: location.line,
         column: location.column,
         reason: 'rel must include both noopener and noreferrer',
@@ -115,7 +117,6 @@ function run(rootDir = process.cwd()) {
   const failures = [];
   for (const filePath of htmlFiles) {
     const html = fs.readFileSync(filePath, 'utf8');
-    anchorTagRegex.lastIndex = 0;
     failures.push(...checkHtmlFile(html, path.relative(rootDir, filePath)));
   }
 
@@ -156,6 +157,7 @@ function main() {
 
 module.exports = {
   checkHtmlFile,
+  findAnchorTags,
   findHtmlFiles,
   getLineColumn,
   run,

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const {
   checkHtmlFile,
   findAnchorTags,
+  getBlankTargetRelFailureReason,
   getLineColumn,
   run,
 } = require('./check-external-links.js');
@@ -25,6 +26,30 @@ test('findAnchorTags returns tag text and source indexes', () => {
     { tag: '<a href="/">', index: 6 },
     { tag: '<a href="/about">', index: 37 },
   ]);
+});
+
+test('getBlankTargetRelFailureReason ignores non-blank targets', () => {
+  assert.equal(getBlankTargetRelFailureReason('<a href="/local">local</a>'), null);
+  assert.equal(getBlankTargetRelFailureReason('<a href="/local" target="_self">local</a>'), null);
+});
+
+test('getBlankTargetRelFailureReason validates required rel tokens', () => {
+  assert.equal(
+    getBlankTargetRelFailureReason('<a href="https://example.com" target="_blank">bad</a>'),
+    'missing rel attribute',
+  );
+  assert.equal(
+    getBlankTargetRelFailureReason(
+      '<a href="https://example.com" target="_blank" rel="noopener external">bad</a>',
+    ),
+    'rel must include both noopener and noreferrer',
+  );
+  assert.equal(
+    getBlankTargetRelFailureReason(
+      '<a href="https://example.com" target="_BLANK" rel="NOOPENER noreferrer external">ok</a>',
+    ),
+    null,
+  );
 });
 
 test('checkHtmlFile passes when target=_blank includes noopener noreferrer', () => {

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -4,13 +4,27 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { checkHtmlFile, getLineColumn, run } = require('./check-external-links.js');
+const {
+  checkHtmlFile,
+  findAnchorTags,
+  getLineColumn,
+  run,
+} = require('./check-external-links.js');
 
 test('getLineColumn returns 1-based line/column', () => {
   const text = 'first\nsecond\nthird';
   assert.deepEqual(getLineColumn(text, 0), { line: 1, column: 1 });
   assert.deepEqual(getLineColumn(text, 8), { line: 2, column: 3 });
   assert.deepEqual(getLineColumn(text, text.length), { line: 3, column: 6 });
+});
+
+test('findAnchorTags returns tag text and source indexes', () => {
+  const html = '<main><a href="/">home</a><p>text</p><a href="/about">about</a></main>';
+
+  assert.deepEqual(findAnchorTags(html), [
+    { tag: '<a href="/">', index: 6 },
+    { tag: '<a href="/about">', index: 37 },
+  ]);
 });
 
 test('checkHtmlFile passes when target=_blank includes noopener noreferrer', () => {

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -28,6 +28,14 @@ test('findAnchorTags returns tag text and source indexes', () => {
   ]);
 });
 
+test('findAnchorTags preserves quoted greater-than characters inside attributes', () => {
+  const html = '<a href="https://example.com?q=1>0" aria-label="1 > 0">math</a>';
+
+  assert.deepEqual(findAnchorTags(html), [
+    { tag: '<a href="https://example.com?q=1>0" aria-label="1 > 0">', index: 0 },
+  ]);
+});
+
 test('getBlankTargetRelFailureReason ignores non-blank targets', () => {
   assert.equal(getBlankTargetRelFailureReason('<a href="/local">local</a>'), null);
   assert.equal(getBlankTargetRelFailureReason('<a href="/local" target="_self">local</a>'), null);


### PR DESCRIPTION
## Summary
- Replace the shared global anchor-tag regex scan with a local `findAnchorTags()` helper.
- Make anchor tag extraction quote-aware so `>` inside quoted attributes does not truncate the tag.
- Keep source indexes explicit for diagnostics and isolate `_blank` target `rel` policy validation behind `getBlankTargetRelFailureReason()`.
- Add focused coverage for anchor tag extraction, policy reasons, index reporting, and quoted greater-than attributes.

## Validation
- `node --test scripts/check-external-links.test.js` - passed; 13 tests passed.
- `node scripts/check-external-links.js` - passed; 1 HTML file scanned.
- `git diff --check` - passed.

## Risk
- Low; this is an internal checker refactor with unchanged validation rules.

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [x] Exactly one completion update posted to topic 713
