### PR TITLE
docs: document local regression test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ python3 -m http.server 8000
 **Quality checks:**
 ```bash
 node scripts/check-external-links.js
+node --test scripts/check-external-links.test.js
 ```
 
-This validates that every `target="_blank"` link across all repo HTML files includes `rel="noopener noreferrer"` to prevent reverse-tabnabbing.
+These match the `site-checks` CI workflow: validating that every `target="_blank"` link across all repo HTML files includes `rel="noopener noreferrer"` to prevent reverse-tabnabbing, then running the checker regression tests.
 
 **Deploy:**
 - Push/merge to `master` → auto-deploys to GitHub Pages


### PR DESCRIPTION
## Summary
- Document the local regression test command alongside the external-link checker.
- Clarify that the README quality checks mirror the `site-checks` CI workflow.

## Validation
- `node scripts/check-external-links.js` - passed
- `node --test scripts/check-external-links.test.js` - passed

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [ ] Exactly one completion update posted to topic 713
