### PR TITLE
chore: limit site checks workflow permissions

### DIFF
--- a/.github/workflows/site-checks.yml
+++ b/.github/workflows/site-checks.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   external-link-safety:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit read-only `contents: read` permissions to the site-checks GitHub Actions workflow.
- Leave existing workflow triggers and validation commands unchanged.

## Validation
- `node scripts/check-external-links.js`
- `node --test scripts/check-external-links.test.js`

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [x] Exactly one completion update posted to topic 713