### PR TITLE
fix: keep newsletter signup from replacing site

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
         <div class="cta-box">
             <h3>Get leadership insights in your inbox</h3>
             <p>Real challenges, practical approaches, no fluff. Delivered weekly.</p>
-            <a href="https://the.leadingintech.email/subscribe?utm_campaign=robansuini&utm_source=website" class="btn">
+            <a href="https://the.leadingintech.email/subscribe?utm_campaign=robansuini&utm_source=website" class="btn" target="_blank" rel="noopener noreferrer">
                 Subscribe to the Newsletter
             </a>
         </div>


### PR DESCRIPTION
## Summary
- Open the newsletter subscribe CTA in a new tab/window.
- Keep reverse-tabnabbing protection with `rel="noopener noreferrer"`.

## Validation
- `node scripts/check-external-links.js` -> passed
- `node --test scripts/check-external-links.test.js` -> passed

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (can be "none")
- [ ] Exactly one completion update posted to topic 713