### PR TITLE
fix: make keyboard focus visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,11 @@
             color: var(--primary);
         }
 
+        a:focus-visible {
+            outline: 3px solid var(--primary);
+            outline-offset: 4px;
+        }
+
         section {
             margin-bottom: 64px;
         }
@@ -172,6 +177,10 @@
         .btn:hover {
             transform: translateY(-2px);
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+        }
+
+        .cta-box a:focus-visible {
+            outline-color: white;
         }
 
         footer {


### PR DESCRIPTION
## Summary
- add a clear 3px focus outline for keyboard-focused links
- use a white outline inside the blue newsletter CTA for reliable contrast

## Validation
- `node scripts/check-external-links.js`
- `node --test scripts/check-external-links.test.js` (9 passed)
- focused CSS assertions for outline width, offset, and CTA override
- `git diff --check origin/master...HEAD`

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed (none beyond low-risk focus styling)
- [x] Exactly one completion update posted to topic 713
