### PR TITLE
chore: pin Font Awesome stylesheet integrity

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Roberto Ansuini - Engineering Leadership & Tools</title>
     <meta name="description" content="Engineering manager since 2011. Helping people and technology work better together through practical leadership tools and insights.">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer">
     <script async defer data-domain="robansuini.com" src="https://robansuini-work.nsuini.workers.dev/js/script.js"></script>
     <style>
         * {

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -199,6 +199,21 @@ test('site social links have explicit accessible labels', () => {
   );
 });
 
+test('third-party Font Awesome stylesheet is pinned with subresource integrity', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const stylesheet = html.match(
+    /<link\b[^>]*href="https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/font-awesome\/6\.5\.1\/css\/all\.min\.css"[^>]*>/,
+  )?.[0];
+
+  assert.ok(stylesheet, 'expected the pinned Font Awesome stylesheet to exist');
+  assert.equal(
+    getAttributeValue(stylesheet, 'integrity'),
+    'sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==',
+  );
+  assert.equal(getAttributeValue(stylesheet, 'crossorigin'), 'anonymous');
+  assert.equal(getAttributeValue(stylesheet, 'referrerpolicy'), 'no-referrer');
+});
+
 test('checkHtmlFile ignores unsafe anchors inside HTML comments', () => {
   const html = '<!-- <a href="https://example.com" target="_blank">commented out</a> -->';
   const failures = checkHtmlFile(html, 'index.html');

--- a/tasks/work-item.md
+++ b/tasks/work-item.md
@@ -1,0 +1,16 @@
+# Work item: Pin third-party stylesheet content
+
+## Goal
+
+Prevent an unexpected CDN response from executing as trusted Font Awesome CSS on the site.
+
+## Acceptance criteria
+
+- Pin the Font Awesome 6.5.1 stylesheet with a SHA-512 Subresource Integrity digest.
+- Fetch the stylesheet anonymously without sending referrer data.
+- Add regression coverage for the URL, digest, and cross-origin attributes.
+
+## Validation
+
+- `node scripts/check-external-links.js`
+- `node --test scripts/check-external-links.test.js`


### PR DESCRIPTION
## Summary
- pin the Font Awesome 6.5.1 CDN stylesheet with a SHA-512 Subresource Integrity digest
- request the stylesheet anonymously without referrer data
- add regression coverage for the pinned URL and security attributes

## Validation
- `node scripts/check-external-links.js` (passed; 1 HTML file scanned)
- `node --test scripts/check-external-links.test.js` (27 passed)
- `git diff --check` (passed)

## Risk
- Low: a mismatched CDN response will intentionally block icon styling instead of trusting changed content

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `tasks/work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed
- [x] Exactly one completion update posted to topic 713
