### PR TITLE
fix: declare canonical homepage URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Roberto Ansuini - Engineering Leadership & Tools</title>
     <meta name="description" content="Engineering manager since 2011. Helping people and technology work better together through practical leadership tools and insights.">
+    <link rel="canonical" href="https://robansuini.com/">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer">
     <script async defer data-domain="robansuini.com" src="https://robansuini-work.nsuini.workers.dev/js/script.js"></script>
     <style>

--- a/scripts/check-external-links.test.js
+++ b/scripts/check-external-links.test.js
@@ -199,6 +199,14 @@ test('site social links have explicit accessible labels', () => {
   );
 });
 
+test('homepage declares its absolute canonical URL', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const canonical = html.match(/<link\b[^>]*rel="canonical"[^>]*>/)?.[0];
+
+  assert.ok(canonical, 'expected a canonical link to exist');
+  assert.equal(getAttributeValue(canonical, 'href'), 'https://robansuini.com/');
+});
+
 test('third-party Font Awesome stylesheet is pinned with subresource integrity', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const stylesheet = html.match(

--- a/tasks/work-item.md
+++ b/tasks/work-item.md
@@ -1,14 +1,13 @@
-# Work item: Pin third-party stylesheet content
+# Work item: Declare the canonical homepage URL
 
 ## Goal
 
-Prevent an unexpected CDN response from executing as trusted Font Awesome CSS on the site.
+Tell search engines which homepage URL should be indexed when the site is reached through alternate GitHub Pages URLs.
 
 ## Acceptance criteria
 
-- Pin the Font Awesome 6.5.1 stylesheet with a SHA-512 Subresource Integrity digest.
-- Fetch the stylesheet anonymously without sending referrer data.
-- Add regression coverage for the URL, digest, and cross-origin attributes.
+- Declare `https://robansuini.com/` as the homepage canonical URL.
+- Add regression coverage that detects a missing or changed canonical URL.
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- declare `https://robansuini.com/` as the homepage canonical URL
- prevent duplicate indexing through alternate GitHub Pages URLs
- add regression coverage for the canonical link and absolute URL

## Validation
- `node scripts/check-external-links.js` (passed; 1 HTML file scanned)
- `node --test scripts/check-external-links.test.js` (28 passed)
- `git diff --check` (passed)

## Risk
- Low: this only adds search-engine metadata and does not change rendered content

## PR Checklist (AI-DLC-lite)
- [x] Intent and scope match `tasks/work-item.md`
- [x] Acceptance criteria covered by tests or explicit verification
- [x] Validation commands + results included
- [x] Risk check completed
- [x] Exactly one completion update posted to topic 713
